### PR TITLE
Reaction Roles

### DIFF
--- a/events/reactionRoles.js
+++ b/events/reactionRoles.js
@@ -1,0 +1,51 @@
+const reactionRoleMap = {
+  // TODO: Make reactions
+}
+
+const ReactionRolesAdd = {
+  name: 'messageReactionAdd',
+  async execute(reaction, user) {
+    if (reaction.message.channel.name.equals('roles')) {
+      if (await handleReaction(reaction)) {
+        const role = findRole(reaction)
+        if (role !== null) {
+          user.roles.add(role)
+        }
+      }
+    }
+  }
+}
+const ReactionRolesRemove = {
+  name: 'messageReactionRemove',
+  async execute(reaction, user) {
+    if (reaction.message.channel.name.equals('roles')) {
+      if (await handleReaction(reaction)) {
+        const role = findRole(reaction)
+        if (role !== null) {
+          user.roles.remove()
+        }
+      }
+    }
+  }
+}
+
+const findRole = reaction => {
+  const roleName = reactionRoleMap[reaction.emoji.name]
+  return reaction.guild.roles.cache.find(role => role.name === roleName)
+}
+
+const handleReaction = async reaction => {
+  if (reaction.partial) {
+    // If the message this reaction belongs to was removed, the fetching might result in an API error which should be handled
+    try {
+      await reaction.fetch()
+    } catch (error) {
+      console.error('Something went wrong when fetching the message:', error)
+      // Return as `reaction.message.author` may be undefined/null
+      return false
+    }
+  }
+  return true
+}
+
+export default {ReactionRolesRemove, ReactionRolesAdd}


### PR DESCRIPTION
I want to implement a reaction roles channel so people can see the roles that are available and chose what applies to them. This creates more visibility for roles because many people don't know about the /grade and /major. I believe that implementing reaction roles would be much better. Please look over this code as it is untested and once we get some emojis in the discord and roles made we can add them in.